### PR TITLE
Temporary fix for timeout error on GR-CITRUS

### DIFF
--- a/src/board/wakayamarbboard.coffee
+++ b/src/board/wakayamarbboard.coffee
@@ -537,7 +537,11 @@ module.exports = class WakayamaRbBoard extends Board
       ).then(=>
         return @_wrbb._wait("Saving").timeout(WRITE1K_TIMEOUT_MS * ((src.byteLength + 1024) / 1024))
       ).then(=>
-        return @_wrbb._wait("\r\n>").timeout(WRITE1K_TIMEOUT_MS * ((src.byteLength + 1024) / 1024))
+        return @_wrbb._pull(
+          @_wrbb._wait("\r\n>")
+          WRITE1K_TIMEOUT_MS
+          ((src.byteLength + 1024) / 1024)
+        )
       ).then(=>
         return  # Last PromiseValue
       ).finally(=>

--- a/src/board/wakayamarbboard.coffee
+++ b/src/board/wakayamarbboard.coffee
@@ -80,7 +80,7 @@ module.exports = class WakayamaRbBoard extends Board
   CMD_TIMEOUT_MS      = 200
   CMD_RETRIES         = 10
   READ1K_TIMEOUT_MS   = 1000
-  WRITE1K_TIMEOUT_MS  = 2000
+  WRITE1K_TIMEOUT_MS  = 6000
   DELETE_TIMEOUT_MS   = 1000
   V1_VERSION_NEEDLE   = "H [ENTER])"
   V1_VERSION_LINE     = /^(WAKAYAMA\.RB Board) Ver\.([^-]+)-([^,]+),([^(]+)\((?:help->)?H \[ENTER\]\)$/
@@ -537,11 +537,7 @@ module.exports = class WakayamaRbBoard extends Board
       ).then(=>
         return @_wrbb._wait("Saving").timeout(WRITE1K_TIMEOUT_MS * ((src.byteLength + 1024) / 1024))
       ).then(=>
-        return @_wrbb._pull(
-          @_wrbb._wait("\r\n>")
-          WRITE1K_TIMEOUT_MS
-          ((src.byteLength + 1024) / 1024)
-        )
+        return @_wrbb._wait("\r\n>").timeout(WRITE1K_TIMEOUT_MS * ((src.byteLength + 1024) / 1024))
       ).then(=>
         return  # Last PromiseValue
       ).finally(=>


### PR DESCRIPTION
GR-CITRUSにおいて、mrbファイルサイズが大きい場合、実行時に転送に失敗することがあります。mrbのファイルサイズが8kbの場合、20秒以上（実測値）がかかることがあり、現状のタイムアウト設定値ではタイムアウトしてしまうことがあるためです。

GR-CITRUS側の処理も確認しましたが、ファイルサイズが大きくなると空きセクタを見つける処理に時間を要するようになるため（ウェアレベリングを考慮したセクタの平滑化利用の処理が原因で、ファイルサイズの増加に対して空きを見つけるための処理時間が非線形的に増加している？）と思われます。

このタイムアウトが原因でRubicを使えない状態となっておりますため、汚い対策ではありますが、マージのご検討をおねがいします。